### PR TITLE
Fix typo in error message.

### DIFF
--- a/packages/webclient/src/AuthorizerFactory.ts
+++ b/packages/webclient/src/AuthorizerFactory.ts
@@ -11,7 +11,7 @@ export class AuthorizerFactory {
         }
         catch(error) {
             core.debug(error);
-            throw new Error("No credentails found. Add an Azure login action before this action. For more details refer https://github.com/azure/login");
+            throw new Error("No credentials found. Add an Azure login action before this action. For more details refer https://github.com/azure/login");
         }   
     }
 }


### PR DESCRIPTION
Fix a misspelling of "credentials".

I noticed this in an GitHub Actions that uses `Azure/functions-action@v1`, and this was the only hit on GitHub for that text.