### PR TITLE
Enable OneDeploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
     "minimatch": "^3.0.0",
     "node-stream-zip": "1.7.0",
     "shelljs": "^0.3.0",
-    "typed-rest-client": "0.12.0",
+    "typed-rest-client": "1.8.11",
     "uuid": "3.1.0",
-    "xml2js": "0.4.13"
+    "xml2js": "0.6.2"
   },
   "files": [
     "lib/**/*"

--- a/packages/appservice-rest/package.json
+++ b/packages/appservice-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-actions-appservice-rest",
-  "version": "1.3.12",
+  "version": "1.3.13",
   "description": "Azure resource manager and kudu node rest module",
   "keywords": [
     "appservice",

--- a/packages/appservice-rest/src/Kudu/azure-app-kudu-service.ts
+++ b/packages/appservice-rest/src/Kudu/azure-app-kudu-service.ts
@@ -243,6 +243,40 @@ export class Kudu {
         }
     }
 
+    public async oneDeploy(webPackage: string, queryParameters?: Array<string>): Promise<any> {
+        let httpRequest: WebRequest = {
+            method: 'POST',
+            uri: this._client.getRequestUri(`/api/publish`, queryParameters),
+            body: fs.createReadStream(webPackage)
+        };
+
+        try {
+            let response = await this._client.beginRequest(httpRequest, null, 'application/octet-stream');
+            core.debug(`One Deploy response: ${JSON.stringify(response)}`);
+            if (response.statusCode == 200) {
+                core.debug('Deployment passed');
+                return null;
+            }
+            else if (response.statusCode == 202) {
+                let pollableURL: string = response.headers.location;
+                if (!!pollableURL) {
+                    core.debug(`Polling for One Deploy URL: ${pollableURL}`);
+                    return await this._getDeploymentDetailsFromPollURL(pollableURL);
+                }
+                else {
+                    core.debug('One Deploy returned 202 without pollable URL.');
+                    return null;
+                }
+            }
+            else {
+                throw response;
+            }
+        }
+        catch (error) {
+            throw Error("Failed to deploy web package using OneDeploy to App Service.\n" + this._getFormattedError(error));
+        }
+    }
+
 
     public async getDeploymentDetails(deploymentID: string): Promise<any> {
         try {

--- a/packages/appservice-rest/src/Utilities/KuduServiceUtility.ts
+++ b/packages/appservice-rest/src/Utilities/KuduServiceUtility.ts
@@ -117,11 +117,6 @@ export class KuduServiceUtility {
                 queryParameters.push('type=' + encodeURIComponent(type));
             }
 
-            else {
-                console.warn('No deployment type provided. Defaulting to type=zip');
-                queryParameters.push('type=zip');
-            }
-
             if (targetPath) {
                 queryParameters.push('path=' + encodeURIComponent(targetPath));
             }

--- a/packages/appservice-rest/src/Utilities/KuduServiceUtility.ts
+++ b/packages/appservice-rest/src/Utilities/KuduServiceUtility.ts
@@ -8,6 +8,7 @@ import fs = require('fs');
 const deploymentFolder: string = 'site/deployments';
 const manifestFileName: string = 'manifest';
 const GITHUB_ZIP_DEPLOY: string = 'GITHUB_ZIP_DEPLOY';
+const GITHUB_ONE_DEPLOY: string = 'GITHUB_ONE_DEPLOY';
 const GITHUB_DEPLOY: string = 'GITHUB';
 
 export class KuduServiceUtility {
@@ -99,6 +100,50 @@ export class KuduServiceUtility {
             return deploymentDetails.id;
         }
         catch(error) {
+            core.error('Failed to deploy web package to App Service.');
+            throw error;
+        }
+    }
+
+    public async deployUsingOneDeploy(packagePath: string, customMessage?: any, targetPath?: any, type?: any, clean?: any, restart?: any): Promise<string> {
+        try {
+            console.log('Package deployment using OneDeploy initiated.');
+            let queryParameters: Array<string> = [
+                'async=true',
+                'deployer=' + GITHUB_ONE_DEPLOY
+            ];
+
+            if (type) {
+                queryParameters.push('type=' + encodeURIComponent(type));
+            }
+
+            else {
+                console.warn('No deployment type provided. Defaulting to type=zip');
+                queryParameters.push('type=zip');
+            }
+
+            if (targetPath) {
+                queryParameters.push('path=' + encodeURIComponent(targetPath));
+            }
+
+            if (clean) {
+                queryParameters.push('clean=' + encodeURIComponent(clean));
+            }
+
+            if (restart) {
+                queryParameters.push('restart=' + encodeURIComponent(restart));
+            }
+
+            var deploymentMessage = this._getUpdateHistoryRequest(null, null, customMessage).message;
+            queryParameters.push('message=' + encodeURIComponent(deploymentMessage));
+            let deploymentDetails = await this._webAppKuduService.oneDeploy(packagePath, queryParameters);
+            console.log(deploymentDetails);
+            await this._processDeploymentResponse(deploymentDetails);
+            console.log('Successfully deployed web package to App Service.');
+
+            return deploymentDetails.id;
+        }
+        catch (error) {
             core.error('Failed to deploy web package to App Service.');
             throw error;
         }


### PR DESCRIPTION
Enabling OneDeploy to be used for Github Actions. This change is limited to push based deployments with pull based deployments planned for the future. User's will be able to specify the type, clean, restart, and target path parameters. 