### PR TITLE
Stop using publishing profile to get applicationURL

### DIFF
--- a/packages/appservice-rest/src/Arm/azure-app-service.ts
+++ b/packages/appservice-rest/src/Arm/azure-app-service.ts
@@ -29,7 +29,6 @@ export class AzureAppService {
     private _slotUrl: string;
     public _client: ServiceClient;
     private _appServiceConfigurationDetails: AzureAppServiceConfigurationDetails;
-    private _appServicePublishingProfile: any;
     private _appServiceApplicationSetings: AzureAppServiceConfigurationDetails;
     private _appServiceConfigurationSettings: AzureAppServiceConfigurationDetails;
     private _appServiceConnectionString: AzureAppServiceConfigurationDetails;
@@ -81,14 +80,6 @@ export class AzureAppService {
         catch(error) {
             throw Error ("Failed to restart app service " + this._getFormattedName() + ".\n" + getFormattedError(error));
         }
-    }
-
-    public async getPublishingProfileWithSecrets(force?: boolean): Promise<any>{
-        if(force || !this._appServicePublishingProfile) {
-            this._appServicePublishingProfile = await this._getPublishingProfileWithSecrets();
-        }
-
-        return this._appServicePublishingProfile;
     }
 
     public async getPublishingCredentials(): Promise<any> {
@@ -475,30 +466,6 @@ export class AzureAppService {
 
     public getSlot(): string {
         return this._slot ? this._slot : "production";
-    }
-
-    private async _getPublishingProfileWithSecrets(): Promise<any> {
-        try {
-            var httpRequest: WebRequest = {
-                method: 'POST',
-                uri: this._client.getRequestUri(`//subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/${this._slotUrl}/publishxml`,
-                {
-                    '{resourceGroupName}': this._resourceGroup,
-                    '{name}': this._name,
-                }, null, '2016-08-01')
-            }
-
-            var response = await this._client.beginRequest(httpRequest);
-            if(response.statusCode != 200) {
-                throw ToError(response);
-            }
-
-            var publishingProfile = response.body;
-            return publishingProfile;
-        }
-        catch(error) {
-            throw Error("Failed to fetch publishing profile for app service " + this._getFormattedName() + ".\n" + getFormattedError(error));
-        }
     }
 
     private async _getApplicationSettings(): Promise<AzureAppServiceConfigurationDetails> {

--- a/packages/appservice-rest/src/Utilities/AzureAppServiceUtility.ts
+++ b/packages/appservice-rest/src/Utilities/AzureAppServiceUtility.ts
@@ -18,31 +18,10 @@ export class AzureAppServiceUtility {
         this._webClient = new WebClient();
     }
 
-    public async getWebDeployPublishingProfile(): Promise<any> {
-        var publishingProfile = await this._appService.getPublishingProfileWithSecrets();
-        var defer = Q.defer<any>();
-        parseString(publishingProfile, (error, result) => {
-            if(!!error) {
-                defer.reject(error);
-            }
-            var publishProfile = result && result.publishData && result.publishData.publishProfile ? result.publishData.publishProfile : null;
-            if(publishProfile) {
-                for (var index in publishProfile) {
-                    if (publishProfile[index].$ && publishProfile[index].$.publishMethod === "MSDeploy") {
-                        defer.resolve(result.publishData.publishProfile[index].$);
-                    }
-                }
-            }
-            
-            defer.reject('Error : No such deploying method exists.');
-        });
-
-        return defer.promise;
-    }
-
     public async getApplicationURL(virtualApplication?: string): Promise<string> {
-        let webDeployProfile: any =  await this.getWebDeployPublishingProfile();
-        return await webDeployProfile.destinationAppUrl + ( virtualApplication ? "/" + virtualApplication : "" );
+        var app = await this._appService.get()
+        var applicationUri = (app.properties["hostNameSslStates"] || []).find(n => n.hostType == "Standard");
+        return `https://${applicationUri["name"]}` + ( virtualApplication ? "/" + virtualApplication : "" );
     }
 
     public async pingApplication(): Promise<void> {


### PR DESCRIPTION
Removing the usage of publishing profile to obtain host name. Now using an ARM GET request to the site resource. The only remaining usage of the publishing profile here is in Kudu authentication as a fall back if the access token does not work.